### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,8 +9,13 @@ async function getPrice() {
     const data = await res.json();
     if (data['Realtime Currency Exchange Rate']) {
         const rate = data['Realtime Currency Exchange Rate']['5. Exchange Rate'];
-        // Vulnerable to XSS: symbol not sanitized
-        document.getElementById('result').innerHTML = `<b>${symbol}</b>: $${parseFloat(rate).toFixed(2)}`;
+        // Secure: use textContent to avoid XSS
+        const resultElem = document.getElementById('result');
+        resultElem.textContent = ''; // Clear previous content
+        const bold = document.createElement('b');
+        bold.textContent = symbol;
+        resultElem.appendChild(bold);
+        resultElem.appendChild(document.createTextNode(`: $${parseFloat(rate).toFixed(2)}`));
     } else {
         document.getElementById('result').innerHTML = 'Error fetching data';
     }


### PR DESCRIPTION
Potential fix for [https://github.com/HenryKost/cyber-security-project-crypto-checker/security/code-scanning/2](https://github.com/HenryKost/cyber-security-project-crypto-checker/security/code-scanning/2)

To fix this problem, we must ensure that untrusted user input is not interpreted as HTML. The best way is to avoid using `innerHTML` for outputting user data, and instead use `textContent` for the user-controlled part, or build the DOM nodes programmatically. In this case, we can set the symbol as the text content of a `<b>` element, and then append the rest of the text as a text node. This prevents any injected HTML from being interpreted, fully mitigating the XSS risk, while preserving the intended formatting.

**Steps:**
- Replace the assignment to `innerHTML` with code that creates a `<b>` element, sets its `textContent` to the symbol, and appends it and the price to the result element.
- Clear the result element before appending new content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
